### PR TITLE
main,modes: add extra CQL clause option

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,6 +85,8 @@ var (
 
 	measureLatency bool
 	validateData   bool
+
+	extraClause string
 )
 
 const (
@@ -251,6 +253,7 @@ func main() {
 
 	flag.BoolVar(&measureLatency, "measure-latency", true, "measure request latency")
 	flag.BoolVar(&validateData, "validate-data", false, "write meaningful data and validate while reading")
+	flag.StringVar(&extraClause, "extra-clause", "", "extra CQL clause to be appended to the end of used statements")
 
 	var startTimestamp int64
 	flag.Int64Var(&writeRate, "write-rate", 0, "rate of writes (relevant only for time series reads)")

--- a/main.go
+++ b/main.go
@@ -126,6 +126,8 @@ var (
 
 	clientRoutesConnectionIDs string
 	clientRoutesTable         string
+
+	extraClause string
 )
 
 func Query(session Session, request string) {
@@ -504,6 +506,12 @@ func main() {
 		"validate-data",
 		false,
 		"write meaningful data and validate while reading",
+	)
+	flag.StringVar(
+		&extraClause,
+		"extra-clause",
+		"",
+		"extra CQL clause to be appended to the end of used statements",
 	)
 
 	var startTimestamp int64

--- a/modes.go
+++ b/modes.go
@@ -431,9 +431,10 @@ func createWriteTestFuncWithConfig(
 	config = config.normalized()
 	return func(w *worker.Worker) (time.Duration, error) {
 		request := fmt.Sprintf(
-			"INSERT INTO %s.%s (pk, ck, v) VALUES (?, ?, ?)",
+			"INSERT INTO %s.%s (pk, ck, v) VALUES (?, ?, ?) %s",
 			config.KeyspaceName,
 			config.TableName,
+			extraClause,
 		)
 		query := session.Query(request)
 		defer query.Release()
@@ -521,9 +522,10 @@ func DoBatchedWritesWithConfig(
 ) {
 	config = config.normalized()
 	request := fmt.Sprintf(
-		"INSERT INTO %s.%s (pk, ck, v) VALUES (?, ?, ?)",
+		"INSERT INTO %s.%s (pk, ck, v) VALUES (?, ?, ?) %s",
 		config.KeyspaceName,
 		config.TableName,
+		extraClause,
 	)
 
 	RunTest(
@@ -641,7 +643,7 @@ func DoCounterUpdatesWithConfig(
 			ck := workload.NextClusteringKey()
 
 			query := session.Query("UPDATE "+config.KeyspaceName+"."+config.CounterTableName+
-				" SET c1 = c1 + ?, c2 = c2 + ?, c3 = c3 + ?, c4 = c4 + ?, c5 = c5 + ? WHERE pk = ? AND ck = ?").
+				" "+extraClause+" SET c1 = c1 + ?, c2 = c2 + ?, c3 = c3 + ?, c4 = c4 + ?, c5 = c5 + ? WHERE pk = ? AND ck = ?").
 				Bind(ck, ck+1, ck+2, ck+3, ck+4, pk, ck)
 			defer query.Release()
 			queryStr := ""
@@ -715,42 +717,46 @@ func BuildReadQueryStringWithConfig(config ExecutionConfig, table, orderBy strin
 	switch {
 	case config.InRestriction:
 		return fmt.Sprintf(
-			"SELECT %s FROM %s.%s WHERE pk = ? AND ck IN (%s) %s %s",
+			"SELECT %s FROM %s.%s WHERE pk = ? AND ck IN (%s) %s %s %s",
 			selectFields,
 			config.KeyspaceName,
 			table,
 			strings.TrimRight(strings.Repeat("?,", config.RowsPerRequest), ","),
 			orderBy,
 			bypassCacheClause,
+			extraClause,
 		)
 	case config.ProvideUpperBound:
 		return fmt.Sprintf(
-			"SELECT %s FROM %s.%s WHERE pk = ? AND ck >= ? AND ck < ? %s %s",
+			"SELECT %s FROM %s.%s WHERE pk = ? AND ck >= ? AND ck < ? %s %s %s",
 			selectFields,
 			config.KeyspaceName,
 			table,
 			orderBy,
 			bypassCacheClause,
+			extraClause,
 		)
 	case config.NoLowerBound:
 		return fmt.Sprintf(
-			"SELECT %s FROM %s.%s WHERE pk = ? %s LIMIT %d %s",
+			"SELECT %s FROM %s.%s WHERE pk = ? %s LIMIT %d %s %s",
 			selectFields,
 			config.KeyspaceName,
 			table,
 			orderBy,
 			config.RowsPerRequest,
 			bypassCacheClause,
+			extraClause,
 		)
 	default:
 		return fmt.Sprintf(
-			"SELECT %s FROM %s.%s WHERE pk = ? AND ck >= ? %s LIMIT %d %s",
+			"SELECT %s FROM %s.%s WHERE pk = ? AND ck >= ? %s LIMIT %d %s %s",
 			selectFields,
 			config.KeyspaceName,
 			table,
 			orderBy,
 			config.RowsPerRequest,
 			bypassCacheClause,
+			extraClause,
 		)
 	}
 }
@@ -901,7 +907,7 @@ func DoReadsFromTable(
 
 func DoScanTableWithConfig(config ExecutionConfig, session *gocql.Session, w *worker.Worker, workload workloads.Generator, rateLimiter ratelimiter.RateLimiter, _ bool) {
 	config = config.normalized()
-	request := fmt.Sprintf("SELECT * FROM %s.%s WHERE token(pk) >= ? AND token(pk) <= ?", config.KeyspaceName, config.TableName)
+	request := fmt.Sprintf("SELECT * FROM %s.%s WHERE token(pk) >= ? AND token(pk) <= ? %s", config.KeyspaceName, config.TableName, extraClause)
 
 	RunTest(config, w, workload, rateLimiter, func(rb *worker.Worker) (time.Duration, error) {
 		query := session.Query(request)
@@ -1003,9 +1009,10 @@ func createMixedWriteTestFuncWithConfig(
 	config = config.normalized()
 	return func(rb *worker.Worker) (time.Duration, error) {
 		request := fmt.Sprintf(
-			"INSERT INTO %s.%s (pk, ck, v) VALUES (?, ?, ?)",
+			"INSERT INTO %s.%s (pk, ck, v) VALUES (?, ?, ?) %s",
 			config.KeyspaceName,
 			config.TableName,
+			extraClause,
 		)
 		query := session.Query(request)
 		defer query.Release()


### PR DESCRIPTION
The extra-clause option allows appending a custom CQL clause
to all statements in the chosen workload. Example usage:

```
$> ./scylla-bench -mode read -workload sequential -extra-clause "using timeout 10ms"
Results
Time (avg):	 48.997763214s
Total ops:	 49748
Total rows:	 49748
Total errors:	 50252
Operations/s:	 1015.0848019658131
Rows/s:		 1015.0848019658131
Latency:
  max:		 15.040511ms
  99.9th:	 11.468799ms
  99th:		 10.027007ms
  95th:		 8.945663ms
  90th:		 8.388607ms
  median:	 6.062079ms
  mean:		 6.225544ms
```