### PR TITLE
fix(release): set s-b version info for CI built release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Extract scylladb-gocql driver info
+        run: |
+          chmod +x ./scripts/extract-driver-version.sh
+          ./scripts/extract-driver-version.sh >> "$GITHUB_ENV"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,14 @@ builds:
       - v3 # v3 Enables AMD64 SIMD (SSE4.x,AVX2) optimizations
     goarm64:
       - v8.3 # ARM crypto extension for RANDOM Number generation
+    ldflags:
+      - -s -w
+      - -X github.com/scylladb/scylla-bench/internal/version.version={{.Version}}
+      - -X github.com/scylladb/scylla-bench/internal/version.commit={{.Commit}}
+      - -X github.com/scylladb/scylla-bench/internal/version.date={{.Date}}
+      - -X github.com/scylladb/scylla-bench/internal/version.driverVersion={{.Env.DRIVER_VERSION}}
+      - -X github.com/scylladb/scylla-bench/internal/version.driverCommit={{.Env.DRIVER_COMMIT}}
+      - -X github.com/scylladb/scylla-bench/internal/version.driverDate={{.Env.DRIVER_DATE}}
 
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -24,6 +24,10 @@ var (
 	version = "dev"
 	commit  = "unknown"
 	date    = "unknown"
+
+	driverVersion = "unknown"
+	driverCommit  = "unknown"
+	driverDate    = "unknown"
 )
 
 type ComponentInfo struct {
@@ -212,6 +216,15 @@ func extractRepoOwner(repoPath, defaultOwner string) string {
 
 // Extracts driver version info
 func getDriverVersionInfo() ComponentInfo {
+	// check if driver version info was set via ldflags
+	if driverVersion != "unknown" {
+		return ComponentInfo{
+			Version:    driverVersion,
+			CommitSHA:  driverCommit,
+			CommitDate: driverDate,
+		}
+	}
+
 	var (
 		err error
 		sha string

--- a/scripts/extract-driver-version.sh
+++ b/scripts/extract-driver-version.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+echo "Looking for scylla-gocql driver version..." >&2
+DRIVER_VERSION=$(go list -m -json github.com/gocql/gocql | jq -r '.Replace.Version')
+DRIVER_REPO=$(go list -m -json github.com/gocql/gocql | jq -r '.Replace.Path')
+REPO_OWNER=$(echo "$DRIVER_REPO" | cut -d'/' -f2)
+echo "Driver version: $DRIVER_VERSION" >&2
+echo "Driver repository: $DRIVER_REPO (owner: $REPO_OWNER)" >&2
+
+DRIVER_COMMIT="unknown"
+DRIVER_DATE="unknown"
+
+echo "Trying GitHub API for version info..." >&2
+if [ -n "$GITHUB_TOKEN" ]; then
+  echo "Using GitHub token for API requests" >&2
+  AUTH_HEADER="Authorization: token $GITHUB_TOKEN"
+else
+  AUTH_HEADER=""
+fi
+
+# fetch release information
+RELEASE_INFO=$(curl -s -H "$AUTH_HEADER" "https://api.github.com/repos/$REPO_OWNER/gocql/releases/tags/$DRIVER_VERSION" || echo "")
+if [ -n "$RELEASE_INFO" ] && [ "$(echo "$RELEASE_INFO" | grep -c "\"message\": \"Not Found\"")" -eq 0 ]; then
+  DRIVER_DATE=$(echo "$RELEASE_INFO" | grep '"created_at"' | head -1 | cut -d'"' -f4)
+  TAG_INFO=$(curl -s -H "$AUTH_HEADER" "https://api.github.com/repos/$REPO_OWNER/gocql/git/refs/tags/$DRIVER_VERSION" || echo "")
+  if [ -n "$TAG_INFO" ] && [ "$(echo "$TAG_INFO" | grep -c "\"message\": \"Not Found\"")" -eq 0 ]; then
+    DRIVER_COMMIT=$(echo "$TAG_INFO" | grep '"sha"' | head -1 | cut -d'"' -f4)
+  fi
+fi
+
+echo "Driver version info:" >&2
+echo "  Version: $DRIVER_VERSION" >&2
+echo "  Commit:  $DRIVER_COMMIT" >&2
+echo "  Date:    $DRIVER_DATE" >&2
+
+echo "DRIVER_VERSION=$DRIVER_VERSION"
+echo "DRIVER_COMMIT=$DRIVER_COMMIT"
+echo "DRIVER_DATE=$DRIVER_DATE"


### PR DESCRIPTION
The change updates the release CI workflow to ensure that s-b and scylla-gocql version info includes commit date and SHA attributes.

Fixes: https://github.com/scylladb/scylla-bench/issues/178