### PR TITLE
fix: lazily allocate mixed-mode histograms to prevent OOM

### DIFF
--- a/pkg/results/merged_result.go
+++ b/pkg/results/merged_result.go
@@ -43,23 +43,7 @@ func NewMergedResult(clk clock.Clock) *MergedResult {
 			&globalResultConfiguration.latencyHistogramConfiguration,
 			"co-fixed",
 		)
-		// Create separate histograms for mixed mode read/write operations
-		result.RawReadLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"raw-read",
-		)
-		result.CoFixedReadLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"co-fixed-read",
-		)
-		result.RawWriteLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"raw-write",
-		)
-		result.CoFixedWriteLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"co-fixed-write",
-		)
+		// Read/write specific histograms are allocated lazily on first merge.
 	}
 	return result
 }
@@ -93,25 +77,25 @@ func (mr *MergedResult) AddResult(result Result) {
 		}
 		// Merge read/write specific histograms for mixed mode
 		if result.RawReadLatency != nil {
-			droppedRawRead := mr.RawReadLatency.Merge(result.RawReadLatency)
+			droppedRawRead := ensureHistogram(&mr.RawReadLatency, "raw-read").Merge(result.RawReadLatency)
 			if droppedRawRead > 0 {
 				log.Print("dropped raw read: ", droppedRawRead)
 			}
 		}
 		if result.CoFixedReadLatency != nil {
-			droppedCoFixedRead := mr.CoFixedReadLatency.Merge(result.CoFixedReadLatency)
+			droppedCoFixedRead := ensureHistogram(&mr.CoFixedReadLatency, "co-fixed-read").Merge(result.CoFixedReadLatency)
 			if droppedCoFixedRead > 0 {
 				log.Print("dropped co-fixed read: ", droppedCoFixedRead)
 			}
 		}
 		if result.RawWriteLatency != nil {
-			droppedRawWrite := mr.RawWriteLatency.Merge(result.RawWriteLatency)
+			droppedRawWrite := ensureHistogram(&mr.RawWriteLatency, "raw-write").Merge(result.RawWriteLatency)
 			if droppedRawWrite > 0 {
 				log.Print("dropped raw write: ", droppedRawWrite)
 			}
 		}
 		if result.CoFixedWriteLatency != nil {
-			droppedCoFixedWrite := mr.CoFixedWriteLatency.Merge(result.CoFixedWriteLatency)
+			droppedCoFixedWrite := ensureHistogram(&mr.CoFixedWriteLatency, "co-fixed-write").Merge(result.CoFixedWriteLatency)
 			if droppedCoFixedWrite > 0 {
 				log.Print("dropped co-fixed write: ", droppedCoFixedWrite)
 			}

--- a/pkg/results/result.go
+++ b/pkg/results/result.go
@@ -124,6 +124,13 @@ func NewHistogram(config *histogramConfiguration, name string) *hdrhistogram.His
 	return histogram
 }
 
+func ensureHistogram(h **hdrhistogram.Histogram, name string) *hdrhistogram.Histogram {
+	if *h == nil {
+		*h = NewHistogram(&globalResultConfiguration.latencyHistogramConfiguration, name)
+	}
+	return *h
+}
+
 var globalResultConfiguration Configuration
 
 func GetHdrMemoryConsumption(concurrency int) int {

--- a/pkg/results/thread_result.go
+++ b/pkg/results/thread_result.go
@@ -56,23 +56,6 @@ func NewTestThreadResultWithClockAndFlag(clk clock.Clock, flag *atomic.Bool) *Te
 			&globalResultConfiguration.latencyHistogramConfiguration,
 			"co-fixed-lantecy",
 		)
-		// Create separate histograms for mixed mode read/write operations
-		r.FullResult.RawReadLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"raw-read-latency",
-		)
-		r.FullResult.CoFixedReadLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"co-fixed-read-latency",
-		)
-		r.FullResult.RawWriteLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"raw-write-latency",
-		)
-		r.FullResult.CoFixedWriteLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"co-fixed-write-latency",
-		)
 		r.PartialResult.RawLatency = NewHistogram(
 			&globalResultConfiguration.latencyHistogramConfiguration,
 			"raw-latency",
@@ -81,23 +64,8 @@ func NewTestThreadResultWithClockAndFlag(clk clock.Clock, flag *atomic.Bool) *Te
 			&globalResultConfiguration.latencyHistogramConfiguration,
 			"co-fixed-lantecy",
 		)
-		// Create separate histograms for mixed mode read/write operations in partial results
-		r.PartialResult.RawReadLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"raw-read-latency",
-		)
-		r.PartialResult.CoFixedReadLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"co-fixed-read-latency",
-		)
-		r.PartialResult.RawWriteLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"raw-write-latency",
-		)
-		r.PartialResult.CoFixedWriteLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"co-fixed-write-latency",
-		)
+		// Read/write specific histograms are allocated lazily on first use
+		// (only in mixed mode) to avoid unnecessary memory consumption.
 	}
 	r.ResultChannel = make(chan Result, 10000)
 	return r
@@ -153,23 +121,7 @@ func (r *TestThreadResult) ResetPartialResult() {
 			&globalResultConfiguration.latencyHistogramConfiguration,
 			"co-fixed-lantecy",
 		)
-		// Create separate histograms for mixed mode read/write operations in partial results
-		r.PartialResult.RawReadLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"raw-read-latency",
-		)
-		r.PartialResult.CoFixedReadLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"co-fixed-read-latency",
-		)
-		r.PartialResult.RawWriteLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"raw-write-latency",
-		)
-		r.PartialResult.CoFixedWriteLatency = NewHistogram(
-			&globalResultConfiguration.latencyHistogramConfiguration,
-			"co-fixed-write-latency",
-		)
+		// Read/write specific histograms are allocated lazily on first use.
 	}
 }
 
@@ -209,8 +161,8 @@ func (r *TestThreadResult) RecordReadRawLatency(latency time.Duration) {
 	if lv >= globalResultConfiguration.latencyHistogramConfiguration.maxValue {
 		lv = globalResultConfiguration.latencyHistogramConfiguration.maxValue
 	}
-	_ = r.FullResult.RawReadLatency.RecordValue(lv)
-	_ = r.PartialResult.RawReadLatency.RecordValue(lv)
+	_ = ensureHistogram(&r.FullResult.RawReadLatency, "raw-read-latency").RecordValue(lv)
+	_ = ensureHistogram(&r.PartialResult.RawReadLatency, "raw-read-latency").RecordValue(lv)
 }
 
 // RecordReadCoFixedLatency records coordinated omission fixed latency for read operations in mixed mode
@@ -223,8 +175,8 @@ func (r *TestThreadResult) RecordReadCoFixedLatency(latency time.Duration) {
 	if lv >= globalResultConfiguration.latencyHistogramConfiguration.maxValue {
 		lv = globalResultConfiguration.latencyHistogramConfiguration.maxValue
 	}
-	_ = r.FullResult.CoFixedReadLatency.RecordValue(lv)
-	_ = r.PartialResult.CoFixedReadLatency.RecordValue(lv)
+	_ = ensureHistogram(&r.FullResult.CoFixedReadLatency, "co-fixed-read-latency").RecordValue(lv)
+	_ = ensureHistogram(&r.PartialResult.CoFixedReadLatency, "co-fixed-read-latency").RecordValue(lv)
 }
 
 // RecordWriteRawLatency records raw latency for write operations in mixed mode
@@ -237,8 +189,8 @@ func (r *TestThreadResult) RecordWriteRawLatency(latency time.Duration) {
 	if lv >= globalResultConfiguration.latencyHistogramConfiguration.maxValue {
 		lv = globalResultConfiguration.latencyHistogramConfiguration.maxValue
 	}
-	_ = r.FullResult.RawWriteLatency.RecordValue(lv)
-	_ = r.PartialResult.RawWriteLatency.RecordValue(lv)
+	_ = ensureHistogram(&r.FullResult.RawWriteLatency, "raw-write-latency").RecordValue(lv)
+	_ = ensureHistogram(&r.PartialResult.RawWriteLatency, "raw-write-latency").RecordValue(lv)
 }
 
 // RecordWriteCoFixedLatency records coordinated omission fixed latency for write operations in mixed mode
@@ -251,8 +203,8 @@ func (r *TestThreadResult) RecordWriteCoFixedLatency(latency time.Duration) {
 	if lv >= globalResultConfiguration.latencyHistogramConfiguration.maxValue {
 		lv = globalResultConfiguration.latencyHistogramConfiguration.maxValue
 	}
-	_ = r.FullResult.CoFixedWriteLatency.RecordValue(lv)
-	_ = r.PartialResult.CoFixedWriteLatency.RecordValue(lv)
+	_ = ensureHistogram(&r.FullResult.CoFixedWriteLatency, "co-fixed-write-latency").RecordValue(lv)
+	_ = ensureHistogram(&r.PartialResult.CoFixedWriteLatency, "co-fixed-write-latency").RecordValue(lv)
 }
 
 func (r *TestThreadResult) SubmitResult() {


### PR DESCRIPTION
## Summary

- Mixed mode feature (c9c4165) unconditionally allocated 8 extra HdrHistogram instances per thread for read/write latency tracking, even for non-mixed workloads like timeseries write
- These histograms are large (scaled to 3x timeout) and recreated every second per thread in `ResetPartialResult`, tripling histogram memory and GC churn
- With 150 concurrency on a c6i.xlarge (8GB), this caused OOM ~30 minutes into a 48h longevity test
- Fix: allocate read/write specific histograms lazily via `ensureHistogram()` — only created when mixed mode code paths actually record values. Zero overhead for non-mixed workloads.

Fixes: QATOOLS-152

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run timeseries write workload with same parameters as QATOOLS-152 on c6i.xlarge and confirm stable memory
- [ ] Run mixed mode workload and confirm read/write latency histograms are still reported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)