### PR TITLE
refactor: extract RateLimiter to pkg/rate_limiter package

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gocql/gocql"
 
+	"github.com/scylladb/scylla-bench/pkg/rate_limiter"
 	"github.com/scylladb/scylla-bench/pkg/results"
 	"github.com/scylladb/scylla-bench/pkg/testutil"
 	"github.com/scylladb/scylla-bench/pkg/workloads"
@@ -141,19 +142,19 @@ func modeWithConfig(
 
 	switch modeName(mode) {
 	case modeName(DoWrites):
-		DoWritesWithConfig(config, session, testResult, workload, &UnlimitedRateLimiter{}, validateData)
+		DoWritesWithConfig(config, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
 	case modeName(DoBatchedWrites):
-		DoBatchedWritesWithConfig(config, session, testResult, workload, &UnlimitedRateLimiter{}, validateData)
+		DoBatchedWritesWithConfig(config, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
 	case modeName(DoReads):
-		DoReadsFromTableWithConfig(config, config.TableName, session, testResult, workload, &UnlimitedRateLimiter{}, validateData)
+		DoReadsFromTableWithConfig(config, config.TableName, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
 	case modeName(DoCounterReads):
-		DoReadsFromTableWithConfig(config, config.CounterTableName, session, testResult, workload, &UnlimitedRateLimiter{}, validateData)
+		DoReadsFromTableWithConfig(config, config.CounterTableName, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
 	case modeName(DoCounterUpdates):
-		DoCounterUpdatesWithConfig(config, session, testResult, workload, &UnlimitedRateLimiter{}, validateData)
+		DoCounterUpdatesWithConfig(config, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
 	case modeName(DoScanTable):
-		DoScanTableWithConfig(config, session, testResult, workload, &UnlimitedRateLimiter{}, validateData)
+		DoScanTableWithConfig(config, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
 	case modeName(DoMixed):
-		DoMixedWithConfig(config, session, testResult, workload, &UnlimitedRateLimiter{}, validateData)
+		DoMixedWithConfig(config, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
 	default:
 		t.Fatalf("unsupported mode func")
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gocql/gocql"
 
-	"github.com/scylladb/scylla-bench/pkg/rate_limiter"
+	"github.com/scylladb/scylla-bench/pkg/ratelimiter"
 	"github.com/scylladb/scylla-bench/pkg/results"
 	"github.com/scylladb/scylla-bench/pkg/testutil"
 	"github.com/scylladb/scylla-bench/pkg/workloads"
@@ -142,19 +142,19 @@ func modeWithConfig(
 
 	switch modeName(mode) {
 	case modeName(DoWrites):
-		DoWritesWithConfig(config, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
+		DoWritesWithConfig(config, session, testResult, workload, &ratelimiter.UnlimitedRateLimiter{}, validateData)
 	case modeName(DoBatchedWrites):
-		DoBatchedWritesWithConfig(config, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
+		DoBatchedWritesWithConfig(config, session, testResult, workload, &ratelimiter.UnlimitedRateLimiter{}, validateData)
 	case modeName(DoReads):
-		DoReadsFromTableWithConfig(config, config.TableName, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
+		DoReadsFromTableWithConfig(config, config.TableName, session, testResult, workload, &ratelimiter.UnlimitedRateLimiter{}, validateData)
 	case modeName(DoCounterReads):
-		DoReadsFromTableWithConfig(config, config.CounterTableName, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
+		DoReadsFromTableWithConfig(config, config.CounterTableName, session, testResult, workload, &ratelimiter.UnlimitedRateLimiter{}, validateData)
 	case modeName(DoCounterUpdates):
-		DoCounterUpdatesWithConfig(config, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
+		DoCounterUpdatesWithConfig(config, session, testResult, workload, &ratelimiter.UnlimitedRateLimiter{}, validateData)
 	case modeName(DoScanTable):
-		DoScanTableWithConfig(config, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
+		DoScanTableWithConfig(config, session, testResult, workload, &ratelimiter.UnlimitedRateLimiter{}, validateData)
 	case modeName(DoMixed):
-		DoMixedWithConfig(config, session, testResult, workload, &rate_limiter.UnlimitedRateLimiter{}, validateData)
+		DoMixedWithConfig(config, session, testResult, workload, &ratelimiter.UnlimitedRateLimiter{}, validateData)
 	default:
 		t.Fatalf("unsupported mode func")
 	}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/scylladb/scylla-bench/internal/version"
+	"github.com/scylladb/scylla-bench/pkg/rate_limiter"
 	"github.com/scylladb/scylla-bench/pkg/results"
 	"github.com/scylladb/scylla-bench/pkg/workloads"
 	"github.com/scylladb/scylla-bench/random"
@@ -29,7 +30,7 @@ type (
 	}
 )
 
-type ModeFunc func(session *gocql.Session, testResult *results.TestThreadResult, workload workloads.Generator, rateLimiter RateLimiter, validateData bool)
+type ModeFunc func(session *gocql.Session, testResult *results.TestThreadResult, workload workloads.Generator, rateLimiter rate_limiter.RateLimiter, validateData bool)
 
 type DistributionValue struct {
 	Dist *random.Distribution
@@ -934,7 +935,7 @@ func main() {
 	testResult := RunConcurrently(
 		globalClock,
 		maximumRate,
-		func(i int, testResult *results.TestThreadResult, rateLimiter RateLimiter) {
+		func(i int, testResult *results.TestThreadResult, rateLimiter rate_limiter.RateLimiter) {
 			GetMode(
 				mode,
 			)(

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/scylladb/scylla-bench/internal/version"
-	"github.com/scylladb/scylla-bench/pkg/rate_limiter"
+	"github.com/scylladb/scylla-bench/pkg/ratelimiter"
 	"github.com/scylladb/scylla-bench/pkg/results"
 	"github.com/scylladb/scylla-bench/pkg/workloads"
 	"github.com/scylladb/scylla-bench/random"
@@ -30,7 +30,7 @@ type (
 	}
 )
 
-type ModeFunc func(session *gocql.Session, testResult *results.TestThreadResult, workload workloads.Generator, rateLimiter rate_limiter.RateLimiter, validateData bool)
+type ModeFunc func(session *gocql.Session, testResult *results.TestThreadResult, workload workloads.Generator, rateLimiter ratelimiter.RateLimiter, validateData bool)
 
 type DistributionValue struct {
 	Dist *random.Distribution
@@ -935,7 +935,7 @@ func main() {
 	testResult := RunConcurrently(
 		globalClock,
 		maximumRate,
-		func(i int, testResult *results.TestThreadResult, rateLimiter rate_limiter.RateLimiter) {
+		func(i int, testResult *results.TestThreadResult, rateLimiter ratelimiter.RateLimiter) {
 			GetMode(
 				mode,
 			)(

--- a/modes.go
+++ b/modes.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/scylladb/scylla-bench/internal/clock"
-	"github.com/scylladb/scylla-bench/pkg/rate_limiter"
+	"github.com/scylladb/scylla-bench/pkg/ratelimiter"
 	"github.com/scylladb/scylla-bench/pkg/results"
 	"github.com/scylladb/scylla-bench/pkg/workloads"
 	"github.com/scylladb/scylla-bench/random"
@@ -148,7 +148,7 @@ var (
 func RunConcurrently(
 	clk clock.Clock,
 	maximumRate int,
-	workload func(id int, testResult *results.TestThreadResult, rateLimiter rate_limiter.RateLimiter),
+	workload func(id int, testResult *results.TestThreadResult, rateLimiter ratelimiter.RateLimiter),
 ) *results.TestResults {
 	var timeOffsetUnit int64
 	if maximumRate != 0 {
@@ -166,7 +166,7 @@ func RunConcurrently(
 		testResult := totalResults.GetTestResult(i)
 		go func(i int) {
 			timeOffset := time.Duration(timeOffsetUnit * int64(i))
-			workload(i, testResult, rate_limiter.NewRateLimiter(clk, maximumRate, timeOffset))
+			workload(i, testResult, ratelimiter.NewRateLimiter(clk, maximumRate, timeOffset))
 		}(i)
 	}
 
@@ -227,7 +227,7 @@ func RunTest(
 	config ExecutionConfig,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	test func(rb *results.TestThreadResult) (time.Duration, error),
 ) {
 	config = config.normalized()
@@ -526,7 +526,7 @@ func DoWrites(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	validateData bool,
 ) {
 	RunTest(
@@ -543,7 +543,7 @@ func DoWritesWithConfig(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	validateData bool,
 ) {
 	RunTest(
@@ -560,7 +560,7 @@ func DoBatchedWritesWithConfig(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	validateData bool,
 ) {
 	config = config.normalized()
@@ -650,7 +650,7 @@ func DoBatchedWrites(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	validateData bool,
 ) {
 	DoBatchedWritesWithConfig(DefaultExecutionConfig(), session, threadResult, workload, rateLimiter, validateData)
@@ -660,7 +660,7 @@ func DoCounterUpdates(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	_ bool,
 ) {
 	DoCounterUpdatesWithConfig(DefaultExecutionConfig(), session, threadResult, workload, rateLimiter, false)
@@ -671,7 +671,7 @@ func DoCounterUpdatesWithConfig(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	_ bool,
 ) {
 	config = config.normalized()
@@ -720,7 +720,7 @@ func DoReads(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	validateData bool,
 ) {
 	config := DefaultExecutionConfig()
@@ -731,7 +731,7 @@ func DoCounterReads(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	validateData bool,
 ) {
 	config := DefaultExecutionConfig()
@@ -926,7 +926,7 @@ func DoReadsFromTableWithConfig(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	validateData bool,
 ) {
 	RunTest(config, threadResult, workload, rateLimiter, createReadTestFuncWithConfig(config, table, session, workload, validateData))
@@ -937,13 +937,20 @@ func DoReadsFromTable(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	validateData bool,
 ) {
 	DoReadsFromTableWithConfig(DefaultExecutionConfig(), table, session, threadResult, workload, rateLimiter, validateData)
 }
 
-func DoScanTableWithConfig(config ExecutionConfig, session *gocql.Session, threadResult *results.TestThreadResult, workload workloads.Generator, rateLimiter rate_limiter.RateLimiter, _ bool) {
+func DoScanTableWithConfig(
+	config ExecutionConfig,
+	session *gocql.Session,
+	threadResult *results.TestThreadResult,
+	workload workloads.Generator,
+	rateLimiter ratelimiter.RateLimiter,
+	_ bool,
+) {
 	config = config.normalized()
 	request := fmt.Sprintf("SELECT * FROM %s.%s WHERE token(pk) >= ? AND token(pk) <= ?", config.KeyspaceName, config.TableName)
 
@@ -978,7 +985,7 @@ func DoScanTableWithConfig(config ExecutionConfig, session *gocql.Session, threa
 	})
 }
 
-func DoScanTable(session *gocql.Session, threadResult *results.TestThreadResult, workload workloads.Generator, rateLimiter rate_limiter.RateLimiter, validateData bool) {
+func DoScanTable(session *gocql.Session, threadResult *results.TestThreadResult, workload workloads.Generator, rateLimiter ratelimiter.RateLimiter, validateData bool) {
 	DoScanTableWithConfig(DefaultExecutionConfig(), session, threadResult, workload, rateLimiter, validateData)
 }
 
@@ -987,7 +994,7 @@ func DoMixedWithConfig(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	validateData bool,
 ) {
 	config = config.normalized()
@@ -1031,7 +1038,7 @@ func DoMixed(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter rate_limiter.RateLimiter,
+	rateLimiter ratelimiter.RateLimiter,
 	validateData bool,
 ) {
 	DoMixedWithConfig(DefaultExecutionConfig(), session, threadResult, workload, rateLimiter, validateData)

--- a/modes.go
+++ b/modes.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/scylladb/scylla-bench/internal/clock"
+	"github.com/scylladb/scylla-bench/pkg/rate_limiter"
 	"github.com/scylladb/scylla-bench/pkg/results"
 	"github.com/scylladb/scylla-bench/pkg/workloads"
 	"github.com/scylladb/scylla-bench/random"
@@ -144,56 +145,10 @@ var (
 	globalTotalErrorsPrintOnce sync.Once
 )
 
-type RateLimiter interface {
-	Wait()
-	Expected() time.Time
-}
-
-type UnlimitedRateLimiter struct{}
-
-func (*UnlimitedRateLimiter) Wait() {}
-
-func (*UnlimitedRateLimiter) Expected() time.Time {
-	return time.Time{}
-}
-
-type MaximumRateLimiter struct {
-	clk                 clock.Clock
-	StartTime           time.Time
-	Period              time.Duration
-	CompletedOperations int64
-}
-
-func (mxrl *MaximumRateLimiter) Wait() {
-	mxrl.CompletedOperations++
-	nextRequest := mxrl.StartTime.Add(mxrl.Period * time.Duration(mxrl.CompletedOperations))
-	now := mxrl.clk.Now()
-	if now.Before(nextRequest) {
-		mxrl.clk.Sleep(nextRequest.Sub(now))
-	}
-}
-
-func (mxrl *MaximumRateLimiter) Expected() time.Time {
-	return mxrl.StartTime.Add(mxrl.Period * time.Duration(mxrl.CompletedOperations))
-}
-
-func NewRateLimiter(clk clock.Clock, maximumRate int, _ time.Duration) RateLimiter {
-	if maximumRate == 0 {
-		return &UnlimitedRateLimiter{}
-	}
-	period := time.Duration(int64(time.Second) / int64(maximumRate))
-	return &MaximumRateLimiter{
-		clk:                 clk,
-		Period:              period,
-		StartTime:           clk.Now(),
-		CompletedOperations: 0,
-	}
-}
-
 func RunConcurrently(
 	clk clock.Clock,
 	maximumRate int,
-	workload func(id int, testResult *results.TestThreadResult, rateLimiter RateLimiter),
+	workload func(id int, testResult *results.TestThreadResult, rateLimiter rate_limiter.RateLimiter),
 ) *results.TestResults {
 	var timeOffsetUnit int64
 	if maximumRate != 0 {
@@ -211,7 +166,7 @@ func RunConcurrently(
 		testResult := totalResults.GetTestResult(i)
 		go func(i int) {
 			timeOffset := time.Duration(timeOffsetUnit * int64(i))
-			workload(i, testResult, NewRateLimiter(clk, maximumRate, timeOffset))
+			workload(i, testResult, rate_limiter.NewRateLimiter(clk, maximumRate, timeOffset))
 		}(i)
 	}
 
@@ -272,7 +227,7 @@ func RunTest(
 	config ExecutionConfig,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	test func(rb *results.TestThreadResult) (time.Duration, error),
 ) {
 	config = config.normalized()
@@ -571,7 +526,7 @@ func DoWrites(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	validateData bool,
 ) {
 	RunTest(
@@ -588,7 +543,7 @@ func DoWritesWithConfig(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	validateData bool,
 ) {
 	RunTest(
@@ -605,7 +560,7 @@ func DoBatchedWritesWithConfig(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	validateData bool,
 ) {
 	config = config.normalized()
@@ -695,7 +650,7 @@ func DoBatchedWrites(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	validateData bool,
 ) {
 	DoBatchedWritesWithConfig(DefaultExecutionConfig(), session, threadResult, workload, rateLimiter, validateData)
@@ -705,7 +660,7 @@ func DoCounterUpdates(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	_ bool,
 ) {
 	DoCounterUpdatesWithConfig(DefaultExecutionConfig(), session, threadResult, workload, rateLimiter, false)
@@ -716,7 +671,7 @@ func DoCounterUpdatesWithConfig(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	_ bool,
 ) {
 	config = config.normalized()
@@ -765,7 +720,7 @@ func DoReads(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	validateData bool,
 ) {
 	config := DefaultExecutionConfig()
@@ -776,7 +731,7 @@ func DoCounterReads(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	validateData bool,
 ) {
 	config := DefaultExecutionConfig()
@@ -971,7 +926,7 @@ func DoReadsFromTableWithConfig(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	validateData bool,
 ) {
 	RunTest(config, threadResult, workload, rateLimiter, createReadTestFuncWithConfig(config, table, session, workload, validateData))
@@ -982,13 +937,13 @@ func DoReadsFromTable(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	validateData bool,
 ) {
 	DoReadsFromTableWithConfig(DefaultExecutionConfig(), table, session, threadResult, workload, rateLimiter, validateData)
 }
 
-func DoScanTableWithConfig(config ExecutionConfig, session *gocql.Session, threadResult *results.TestThreadResult, workload workloads.Generator, rateLimiter RateLimiter, _ bool) {
+func DoScanTableWithConfig(config ExecutionConfig, session *gocql.Session, threadResult *results.TestThreadResult, workload workloads.Generator, rateLimiter rate_limiter.RateLimiter, _ bool) {
 	config = config.normalized()
 	request := fmt.Sprintf("SELECT * FROM %s.%s WHERE token(pk) >= ? AND token(pk) <= ?", config.KeyspaceName, config.TableName)
 
@@ -1023,7 +978,7 @@ func DoScanTableWithConfig(config ExecutionConfig, session *gocql.Session, threa
 	})
 }
 
-func DoScanTable(session *gocql.Session, threadResult *results.TestThreadResult, workload workloads.Generator, rateLimiter RateLimiter, validateData bool) {
+func DoScanTable(session *gocql.Session, threadResult *results.TestThreadResult, workload workloads.Generator, rateLimiter rate_limiter.RateLimiter, validateData bool) {
 	DoScanTableWithConfig(DefaultExecutionConfig(), session, threadResult, workload, rateLimiter, validateData)
 }
 
@@ -1032,7 +987,7 @@ func DoMixedWithConfig(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	validateData bool,
 ) {
 	config = config.normalized()
@@ -1076,7 +1031,7 @@ func DoMixed(
 	session *gocql.Session,
 	threadResult *results.TestThreadResult,
 	workload workloads.Generator,
-	rateLimiter RateLimiter,
+	rateLimiter rate_limiter.RateLimiter,
 	validateData bool,
 ) {
 	DoMixedWithConfig(DefaultExecutionConfig(), session, threadResult, workload, rateLimiter, validateData)

--- a/modes_test.go
+++ b/modes_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/scylladb/scylla-bench/internal/clock"
+	"github.com/scylladb/scylla-bench/pkg/rate_limiter"
 )
 
 func Must[T any](v T, err error) T {
@@ -415,7 +416,7 @@ func TestMixedModeCoFixedLatencyRecording(t *testing.T) {
 	// without requiring a database connection by testing the function signature changes
 
 	// Mock rate limiter that returns a known expected time
-	mockRateLimiter := &MaximumRateLimiter{
+	mockRateLimiter := &rate_limiter.MaximumRateLimiter{
 		StartTime: clock.New().Now().Add(-time.Second), // 1 second ago
 		Period:    time.Millisecond * 10,               // 10ms between operations
 	}

--- a/modes_test.go
+++ b/modes_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/scylladb/scylla-bench/internal/clock"
-	"github.com/scylladb/scylla-bench/pkg/rate_limiter"
+	"github.com/scylladb/scylla-bench/pkg/ratelimiter"
 )
 
 func Must[T any](v T, err error) T {
@@ -416,7 +416,7 @@ func TestMixedModeCoFixedLatencyRecording(t *testing.T) {
 	// without requiring a database connection by testing the function signature changes
 
 	// Mock rate limiter that returns a known expected time
-	mockRateLimiter := &rate_limiter.MaximumRateLimiter{
+	mockRateLimiter := &ratelimiter.MaximumRateLimiter{
 		StartTime: clock.New().Now().Add(-time.Second), // 1 second ago
 		Period:    time.Millisecond * 10,               // 10ms between operations
 	}

--- a/pkg/rate_limiter/rate_limiter.go
+++ b/pkg/rate_limiter/rate_limiter.go
@@ -1,0 +1,53 @@
+package rate_limiter
+
+import (
+	"time"
+
+	"github.com/scylladb/scylla-bench/internal/clock"
+)
+
+type RateLimiter interface {
+	Wait()
+	Expected() time.Time
+}
+
+type UnlimitedRateLimiter struct{}
+
+func (*UnlimitedRateLimiter) Wait() {}
+
+func (*UnlimitedRateLimiter) Expected() time.Time {
+	return time.Time{}
+}
+
+type MaximumRateLimiter struct {
+	clk                 clock.Clock
+	StartTime           time.Time
+	Period              time.Duration
+	CompletedOperations int64
+}
+
+func (mxrl *MaximumRateLimiter) Wait() {
+	mxrl.CompletedOperations++
+	nextRequest := mxrl.StartTime.Add(mxrl.Period * time.Duration(mxrl.CompletedOperations))
+	now := mxrl.clk.Now()
+	if now.Before(nextRequest) {
+		mxrl.clk.Sleep(nextRequest.Sub(now))
+	}
+}
+
+func (mxrl *MaximumRateLimiter) Expected() time.Time {
+	return mxrl.StartTime.Add(mxrl.Period * time.Duration(mxrl.CompletedOperations))
+}
+
+func NewRateLimiter(clk clock.Clock, maximumRate int, _ time.Duration) RateLimiter {
+	if maximumRate == 0 {
+		return &UnlimitedRateLimiter{}
+	}
+	period := time.Duration(int64(time.Second) / int64(maximumRate))
+	return &MaximumRateLimiter{
+		clk:                 clk,
+		Period:              period,
+		StartTime:           clk.Now(),
+		CompletedOperations: 0,
+	}
+}

--- a/pkg/ratelimiter/rate_limiter.go
+++ b/pkg/ratelimiter/rate_limiter.go
@@ -1,4 +1,4 @@
-package rate_limiter
+package ratelimiter
 
 import (
 	"time"


### PR DESCRIPTION
## Summary

- Moves `RateLimiter` interface, `UnlimitedRateLimiter`, `MaximumRateLimiter`, and `NewRateLimiter` from inline definitions in `modes.go` into a new dedicated package `pkg/rate_limiter`.
- Pure code move — no behavior change. All callers updated to use the `rate_limiter.` package prefix.
- Part of a series breaking down [PR#93](https://github.com/scylladb/scylla-bench/pull/93) (non-blocking logging) into smaller, independently reviewable chunks.

## Files Changed

| File | Change |
|------|--------|
| `pkg/rate_limiter/rate_limiter.go` | **New**: extracted types |
| `modes.go` | Removed inline types, import `pkg/rate_limiter` |
| `main.go` | Updated `RateLimiter` reference to `rate_limiter.RateLimiter` |
| `modes_test.go` | Updated `MaximumRateLimiter` to `rate_limiter.MaximumRateLimiter` |
| `integration_test.go` | Updated 7x `UnlimitedRateLimiter` to `rate_limiter.UnlimitedRateLimiter` |

## Testing

`make build` and `make test` pass cleanly (all unit tests pass; integration/memory-leak tests skipped as expected without Docker env).