### PR TITLE
refactor: move Round helper to new pkg/tools package

### DIFF
--- a/pkg/results/merged_result.go
+++ b/pkg/results/merged_result.go
@@ -10,6 +10,7 @@ import (
 	"github.com/HdrHistogram/hdrhistogram-go"
 
 	"github.com/scylladb/scylla-bench/internal/clock"
+	"github.com/scylladb/scylla-bench/pkg/tools"
 )
 
 type MergedResult struct {
@@ -220,27 +221,27 @@ func (mr *MergedResult) PrintPartialResult() {
 		latencyHist := mr.getLatencyHistogram()
 		fmt.Printf(
 			withLatencyLineFmt,
-			Round(mr.Time),
+			tools.Round(mr.Time),
 			mr.Operations,
 			mr.ClusteringRows,
 			mr.Errors,
-			Round(
+			tools.Round(
 				time.Duration(latencyHist.Max()*scale),
 			),
-			Round(time.Duration(latencyHist.ValueAtQuantile(99.9)*scale)),
-			Round(time.Duration(latencyHist.ValueAtQuantile(99)*scale)),
-			Round(
+			tools.Round(time.Duration(latencyHist.ValueAtQuantile(99.9)*scale)),
+			tools.Round(time.Duration(latencyHist.ValueAtQuantile(99)*scale)),
+			tools.Round(
 				time.Duration(latencyHist.ValueAtQuantile(95)*scale),
 			),
-			Round(time.Duration(latencyHist.ValueAtQuantile(90)*scale)),
-			Round(
+			tools.Round(time.Duration(latencyHist.ValueAtQuantile(90)*scale)),
+			tools.Round(
 				time.Duration(latencyHist.ValueAtQuantile(50)*scale),
 			),
-			Round(time.Duration(latencyHist.Mean()*float64(scale))),
+			tools.Round(time.Duration(latencyHist.Mean()*float64(scale))),
 			latencyError,
 		)
 	} else {
-		fmt.Printf(withoutLatencyLineFmt, Round(mr.Time), mr.Operations, mr.ClusteringRows, mr.Errors)
+		fmt.Printf(withoutLatencyLineFmt, tools.Round(mr.Time), mr.Operations, mr.ClusteringRows, mr.Errors)
 	}
 }
 

--- a/pkg/results/thread_results_test.go
+++ b/pkg/results/thread_results_test.go
@@ -26,9 +26,15 @@ func TestOutputAlignment(t *testing.T) {
 	// 12m41.2s has fractional seconds (8 chars)
 	// 12m42s has no fractional seconds (6 chars)
 	// Both should align properly with %8v format
-	fmt.Printf(withLatencyLineFmt, tools.Round(12*time.Minute+41*time.Second+200*time.Millisecond), 407603, 407603, 0, "60ms", "28ms", "12ms", "2.7ms", "1.8ms", "852µs", "1.3ms", "")
-	fmt.Printf(withLatencyLineFmt, tools.Round(12*time.Minute+42*time.Second), 401019, 401019, 0, "48ms", "29ms", "9.1ms", "2.3ms", "1.7ms", "852µs", "1.2ms", "")
-	fmt.Printf(withLatencyLineFmt, tools.Round(12*time.Minute+42*time.Second+200*time.Millisecond), 398582, 398582, 0, "49ms", "27ms", "11ms", "2.8ms", "2ms", "950µs", "1.3ms", "")
+	fmt.Printf(withLatencyLineFmt,
+		tools.Round(12*time.Minute+41*time.Second+200*time.Millisecond),
+		407603, 407603, 0, "60ms", "28ms", "12ms", "2.7ms", "1.8ms", "852µs", "1.3ms", "")
+	fmt.Printf(withLatencyLineFmt,
+		tools.Round(12*time.Minute+42*time.Second),
+		401019, 401019, 0, "48ms", "29ms", "9.1ms", "2.3ms", "1.7ms", "852µs", "1.2ms", "")
+	fmt.Printf(withLatencyLineFmt,
+		tools.Round(12*time.Minute+42*time.Second+200*time.Millisecond),
+		398582, 398582, 0, "49ms", "27ms", "11ms", "2.8ms", "2ms", "950µs", "1.3ms", "")
 
 	// Restore stdout and capture output
 	w.Close()

--- a/pkg/results/thread_results_test.go
+++ b/pkg/results/thread_results_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/scylladb/scylla-bench/pkg/tools"
 )
 
 // TestOutputAlignment verifies that time values with and without fractional seconds
@@ -24,9 +26,9 @@ func TestOutputAlignment(t *testing.T) {
 	// 12m41.2s has fractional seconds (8 chars)
 	// 12m42s has no fractional seconds (6 chars)
 	// Both should align properly with %8v format
-	fmt.Printf(withLatencyLineFmt, Round(12*time.Minute+41*time.Second+200*time.Millisecond), 407603, 407603, 0, "60ms", "28ms", "12ms", "2.7ms", "1.8ms", "852µs", "1.3ms", "")
-	fmt.Printf(withLatencyLineFmt, Round(12*time.Minute+42*time.Second), 401019, 401019, 0, "48ms", "29ms", "9.1ms", "2.3ms", "1.7ms", "852µs", "1.2ms", "")
-	fmt.Printf(withLatencyLineFmt, Round(12*time.Minute+42*time.Second+200*time.Millisecond), 398582, 398582, 0, "49ms", "27ms", "11ms", "2.8ms", "2ms", "950µs", "1.3ms", "")
+	fmt.Printf(withLatencyLineFmt, tools.Round(12*time.Minute+41*time.Second+200*time.Millisecond), 407603, 407603, 0, "60ms", "28ms", "12ms", "2.7ms", "1.8ms", "852µs", "1.3ms", "")
+	fmt.Printf(withLatencyLineFmt, tools.Round(12*time.Minute+42*time.Second), 401019, 401019, 0, "48ms", "29ms", "9.1ms", "2.3ms", "1.7ms", "852µs", "1.2ms", "")
+	fmt.Printf(withLatencyLineFmt, tools.Round(12*time.Minute+42*time.Second+200*time.Millisecond), 398582, 398582, 0, "49ms", "27ms", "11ms", "2.8ms", "2ms", "950µs", "1.3ms", "")
 
 	// Restore stdout and capture output
 	w.Close()
@@ -81,9 +83,9 @@ func TestOutputAlignmentWithoutLatency(t *testing.T) {
 	os.Stdout = w
 
 	// Print sample rows with different time formats
-	fmt.Printf(withoutLatencyLineFmt, Round(12*time.Minute+41*time.Second+200*time.Millisecond), 407603, 407603, 0)
-	fmt.Printf(withoutLatencyLineFmt, Round(12*time.Minute+42*time.Second), 401019, 401019, 0)
-	fmt.Printf(withoutLatencyLineFmt, Round(12*time.Minute+42*time.Second+600*time.Millisecond), 402153, 402153, 0)
+	fmt.Printf(withoutLatencyLineFmt, tools.Round(12*time.Minute+41*time.Second+200*time.Millisecond), 407603, 407603, 0)
+	fmt.Printf(withoutLatencyLineFmt, tools.Round(12*time.Minute+42*time.Second), 401019, 401019, 0)
+	fmt.Printf(withoutLatencyLineFmt, tools.Round(12*time.Minute+42*time.Second+600*time.Millisecond), 402153, 402153, 0)
 
 	// Restore stdout and capture output
 	w.Close()

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -1,4 +1,4 @@
-package results
+package tools
 
 import "time"
 


### PR DESCRIPTION
## Summary

- Extracts the `Round(time.Duration)` helper from `pkg/results/auxiliary.go` into a new `pkg/tools` package (`pkg/tools/tools.go`).
- Updates `merged_result.go` and `thread_results_test.go` in `pkg/results` to import and use `tools.Round`.
- Deletes `pkg/results/auxiliary.go`.
- Pure code move — no behavior change.
- Part of a series breaking down [PR#93](https://github.com/scylladb/scylla-bench/pull/93) into smaller chunks. The new `pkg/tools` package will allow future packages (e.g. `pkg/test_run`) to use `Round` without creating an import cycle with `pkg/results`.

## Files Changed

| File | Change |
|------|--------|
| `pkg/tools/tools.go` | **New**: extracted from `pkg/results/auxiliary.go` |
| `pkg/results/auxiliary.go` | **Deleted** |
| `pkg/results/merged_result.go` | Import `pkg/tools`; `Round` → `tools.Round` |
| `pkg/results/thread_results_test.go` | Import `pkg/tools`; `Round` → `tools.Round` |

## Testing

`make build` and `make test` pass cleanly.