### PR TITLE
ci(renovate): stop proposing breaking CQL driver upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,20 +19,15 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": [
-        "github.com/gocql/gocql"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Group all Go module dependencies except scylladb/gocql",
+      "description": "Group all Go module dependencies except the CQL drivers",
       "groupName": "All dependencies",
       "groupSlug": "all-dependencies",
       "matchManagers": [
         "gomod"
       ],
       "matchPackageNames": [
-        "!github.com/scylladb/gocql"
+        "!github.com/scylladb/gocql",
+        "!github.com/gocql/gocql"
       ],
       "enabled": true
     },
@@ -42,6 +37,23 @@
         "github.com/scylladb/gocql"
       ],
       "enabled": true
+    },
+    {
+      "description": "scylladb/gocql is a fork pinned via a replace directive; major bumps track the upstream apache driver and are never drop-in. Bump manually.",
+      "matchPackageNames": [
+        "github.com/scylladb/gocql"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "github.com/gocql/gocql is fully replaced by scylladb/gocql; its version is inert, so never open PRs for it (notably the apache v2 major).",
+      "matchPackageNames": [
+        "github.com/gocql/gocql"
+      ],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Problem

Renovate keeps opening PRs that bump `github.com/gocql/gocql` to the Apache **v2** major. We can't take those: the driver is fully replaced by the ScyllaDB fork, and the whole point of this repo is to exercise that fork.

The existing disable rule for `github.com/gocql/gocql` never worked. It was listed *before* the `All dependencies` group rule, whose `matchPackageNames: ["!github.com/scylladb/gocql"]` also matches `gocql/gocql` and sets `"enabled": true`. Renovate applies `packageRules` in order and the last match wins, so the group rule silently re-enabled it.

## Changes

- Reorder so the CQL driver rules come **last** and actually take effect.
- Disable `github.com/gocql/gocql` outright, and exclude it from the group. Its version in the `require` block is inert behind `replace github.com/gocql/gocql => github.com/scylladb/gocql`, so any PR for it is noise that breaks the build.
- Disable **major** updates for `github.com/scylladb/gocql`. The fork tracks the upstream Apache driver; majors are never drop-in and need manual review.

Minor and patch updates for `github.com/scylladb/gocql` continue to open as their own PRs, unchanged.


https://github.com/scylladb/scylla-bench/pull/311 -> From now on it will not report upgrade to v2 version of apache/gocql

## Tradeoff

There is now no signal at all when the fork cuts a major — no PR and no dashboard entry. If we'd rather see it listed but not opened, swap the major rule's `"enabled": false` for `"dependencyDashboardApproval": true`.